### PR TITLE
Correct bug

### DIFF
--- a/app/models/wunderground.rb
+++ b/app/models/wunderground.rb
@@ -38,9 +38,9 @@ class Wunderground
   end
 
   def convert_to_meridian military_hour
-    if military_hour == (0 || 12)
+    if military_hour == 0
       "12"
-    elsif military_hour < 12
+    elsif military_hour <= 12
       military_hour.to_s 
     else
       (military_hour - 12).to_s


### PR DESCRIPTION
## Problem

The report would print out '00' instead of '12' at noon. 
## Cause

Ordering error. `military_hour == (0 || 12)` actually just checks for military hour = 0? but doesn't check for military_hour = 12. The || operator was not doing what I wanted it to do, because it comes after the == operator.
## Solution

This could be fixed with `military_hour == 0 || military_hour == 12)` or `[0, 12].include? military_hour` 

I instead resolved it by changing it to `military_hour == 0` and adding an = sign to `elsif military_hour <= 12`
